### PR TITLE
feat: adjust internal logic of `ckb-ics` to be ready for the packet test between two Ckb4Ibc endpoints

### DIFF
--- a/axon/src/consts.rs
+++ b/axon/src/consts.rs
@@ -3,5 +3,5 @@ pub const CHANNEL_CELL_CAPACITY: u64 = 1300;
 pub const PACKET_CELL_CAPACITY: u64 = 1300;
 pub const CONNECTION_CELL_CAPACITY: u64 = 1300;
 
-pub const CHANNEL_ID_PREFIX: &'static str = "ckb4ibc-channel-";
-pub const CONNECTION_ID_PREFIX: &'static str = "ckb4ibc-connection-";
+pub const CHANNEL_ID_PREFIX: &str = "channel-";
+pub const CONNECTION_ID_PREFIX: &str = "connection-";

--- a/axon/src/consts.rs
+++ b/axon/src/consts.rs
@@ -1,7 +1,7 @@
-// todo
 pub const CHANNEL_CELL_CAPACITY: u64 = 1300;
 pub const PACKET_CELL_CAPACITY: u64 = 1300;
 pub const CONNECTION_CELL_CAPACITY: u64 = 1300;
 
 pub const CHANNEL_ID_PREFIX: &str = "channel-";
 pub const CONNECTION_ID_PREFIX: &str = "connection-";
+pub const COMMITMENT_PREFIX: &[u8] = "ibc".as_bytes();

--- a/axon/src/handler.rs
+++ b/axon/src/handler.rs
@@ -297,7 +297,7 @@ pub fn handle_msg_connection_open_init<C: Client>(
     }
 
     let connection = new_connections.connections.last().unwrap();
-    if convert_string_to_client_id(&connection.client_id) != client.client_id() {
+    if convert_string_to_client_id(&connection.client_id)? != client.client_id() {
         return Err(VerifyError::WrongClient);
     }
 
@@ -337,7 +337,7 @@ pub fn handle_msg_connection_open_try<C: Client>(
     }
 
     let connection = new_connections.connections.last().unwrap();
-    if convert_string_to_client_id(&connection.client_id) != client.client_id() {
+    if convert_string_to_client_id(&connection.client_id)? != client.client_id() {
         return Err(VerifyError::WrongClient);
     }
 
@@ -529,7 +529,7 @@ pub fn handle_msg_channel_open_init<C: Client>(
     let conn_id = convert_connection_id_to_index(&new.connection_hops[0])?;
     let conn = &ibc_connections.connections[conn_id];
 
-    if convert_string_to_client_id(&conn.client_id) != client.client_id() {
+    if convert_string_to_client_id(&conn.client_id)? != client.client_id() {
         return Err(VerifyError::WrongConnectionClient);
     }
 
@@ -556,7 +556,7 @@ pub fn handle_msg_channel_open_try<C: Client>(
     let conn_id = convert_connection_id_to_index(&new.connection_hops[0])?;
     let conn = &ibc_connections.connections[conn_id];
 
-    if convert_string_to_client_id(&conn.client_id) != client.client_id() {
+    if convert_string_to_client_id(&conn.client_id)? != client.client_id() {
         return Err(VerifyError::WrongConnectionClient);
     }
 

--- a/axon/src/lib.rs
+++ b/axon/src/lib.rs
@@ -212,8 +212,10 @@ pub fn convert_client_id_to_string(client_id: [u8; 32]) -> String {
     format!("{:x}", H256::from(client_id))
 }
 
-pub fn convert_string_to_client_id(s: &str) -> [u8; 32] {
-    H256::from_str(s).unwrap().into()
+pub fn convert_string_to_client_id(s: &str) -> Result<[u8; 32], VerifyError> {
+    Ok(H256::from_str(s)
+        .map_err(|_| VerifyError::WrongClient)?
+        .into())
 }
 
 pub fn convert_connection_id_to_index(connection_id: &str) -> Result<usize, VerifyError> {
@@ -242,7 +244,7 @@ mod tests {
             25, 26, 27, 28, 29, 30, 31, 32,
         ];
         let s = convert_client_id_to_string(actual);
-        let r = convert_string_to_client_id(&s);
+        let r = convert_string_to_client_id(&s).unwrap();
         assert_eq!(actual, r);
     }
 

--- a/axon/src/message.rs
+++ b/axon/src/message.rs
@@ -48,7 +48,7 @@ pub enum MsgType {
 
 impl Encodable for MsgType {
     fn rlp_append(&self, s: &mut rlp::RlpStream) {
-        let t = self.clone() as u8;
+        let t = *self as u8;
         s.append(&t);
     }
 }

--- a/axon/src/object.rs
+++ b/axon/src/object.rs
@@ -43,6 +43,7 @@ pub enum VerifyError {
     WrongChannelState,
     WrongChannel,
     WrongChannelArgs,
+    WrongChannelSequence,
 
     WrongPacketSequence,
     WrongPacketStatus,

--- a/axon/src/object.rs
+++ b/axon/src/object.rs
@@ -60,7 +60,7 @@ pub enum State {
 
 impl Encodable for State {
     fn rlp_append(&self, s: &mut rlp::RlpStream) {
-        let state = self.clone() as u8;
+        let state = *self as u8;
         s.begin_list(1);
         s.append(&state);
     }
@@ -92,7 +92,7 @@ pub enum Ordering {
 
 impl Encodable for Ordering {
     fn rlp_append(&self, s: &mut rlp::RlpStream) {
-        let ordering = self.clone() as u8;
+        let ordering = *self as u8;
         s.begin_list(1);
         s.append(&ordering);
     }

--- a/axon/src/proof.rs
+++ b/axon/src/proof.rs
@@ -5,7 +5,7 @@ use ethereum_types::{Address, Bloom, H256, U256, U64};
 use rlp::{Decodable, Encodable, RlpStream};
 use rlp_derive::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ObjectProof {
     pub receipt: TransactionReceipt,
     pub receipt_proof: Vec<Vec<u8>>,
@@ -41,18 +41,6 @@ impl Decodable for ObjectProof {
             state_root,
             axon_proof,
         })
-    }
-}
-
-impl Default for ObjectProof {
-    fn default() -> Self {
-        Self {
-            receipt: Default::default(),
-            receipt_proof: Default::default(),
-            block: Vec::new(),
-            state_root: Default::default(),
-            axon_proof: Vec::new(),
-        }
     }
 }
 
@@ -191,7 +179,7 @@ pub fn encode_receipt(receipt: &TransactionReceipt) -> Vec<u8> {
     }
 }
 
-fn normalize_v(v: u64, chain_id: U64) -> u64 {
+pub fn normalize_v(v: u64, chain_id: U64) -> u64 {
     if v > 1 {
         v - chain_id.as_u64() * 2 - 35
     } else {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "nightly"
-# channel = "nightly-2023-03-09"


### PR DESCRIPTION
1. since the `channel.connection_hops` saves `usize` as its item type, this makes a hard work to extract total `connection_id` through a channel end, so change it into `String` type to make things easier to do
2. `cargo clippy` announced too many optimization suggestions
3. compatible work:
a. add `commitment_prefix` to connection counterparty object
b. add `versions` to connection end object
c. add `timeout_height` and `timeout_timestamp` to packet object
4. make `PacketArgs` generate prefix-search key for ckb-indexer
5. change sequence logic in `IbcChannel`