### PR TITLE
bug: fix a bug in the check of packet_args comparing with ibc_packet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,3 @@
 [workspace]
-members = [
-    "axon",
-]
+resolver = "2"
+members = ["axon"]

--- a/axon/src/handler/mod.rs
+++ b/axon/src/handler/mod.rs
@@ -503,9 +503,9 @@ pub fn handle_msg_recv_packet<C: Client>(
         return Err(VerifyError::WrongChannelArgs);
     }
 
-    if packet_args.port_id != convert_hex_to_port_id(&ibc_packet.packet.source_port_id)?
+    if packet_args.port_id != convert_hex_to_port_id(&ibc_packet.packet.destination_port_id)?
         || packet_args.sequence != ibc_packet.packet.sequence
-        || get_channel_id_str(packet_args.channel_id) != ibc_packet.packet.source_channel_id
+        || get_channel_id_str(packet_args.channel_id) != ibc_packet.packet.destination_channel_id
     {
         return Err(VerifyError::WrongPacketArgs);
     }


### PR DESCRIPTION
a bug revealed while debugging sending RecvPacket transaction from Forcerelay, which is comparing packet.channel_id with source_channel_id and the correct one is target_channel_id