### PR TITLE
bug: remove wrong sequence_send check in ack_packet

### DIFF
--- a/axon/src/handler/mod.rs
+++ b/axon/src/handler/mod.rs
@@ -565,10 +565,6 @@ pub fn handle_msg_ack_packet<C: Client>(
         return Err(VerifyError::WrongPacketContent);
     }
 
-    if old_ibc_packet.packet.sequence != old_channel.sequence.next_sequence_sends {
-        return Err(VerifyError::WrongPacketSequence);
-    }
-
     let is_unorder = if old_channel.order == Ordering::Unordered {
         true
     } else {

--- a/axon/src/handler/mod.rs
+++ b/axon/src/handler/mod.rs
@@ -6,7 +6,8 @@ use crate::consts::COMMITMENT_PREFIX;
 use crate::message::{
     Envelope, MsgAckPacket, MsgChannelOpenAck, MsgChannelOpenConfirm, MsgChannelOpenInit,
     MsgChannelOpenTry, MsgConnectionOpenAck, MsgConnectionOpenConfirm, MsgConnectionOpenInit,
-    MsgConnectionOpenTry, MsgRecvPacket, MsgSendPacket, MsgType, MsgWriteAckPacket,
+    MsgConnectionOpenTry, MsgConsumeAckPacket, MsgRecvPacket, MsgSendPacket, MsgType,
+    MsgWriteAckPacket,
 };
 use crate::object::{
     ChannelCounterparty, ChannelEnd, ConnectionCounterparty, ConnectionEnd, Ordering, PacketAck,
@@ -608,6 +609,18 @@ pub fn handle_msg_write_ack_packet(
 
     if old_ibc_packet.packet != new_ibc_packet.packet {
         return Err(VerifyError::WrongPacketContent);
+    }
+
+    Ok(())
+}
+
+pub fn handle_msg_consume_ack_packet(
+    old_ibc_packet: IbcPacket,
+    _: PacketArgs,
+    _: MsgConsumeAckPacket,
+) -> Result<(), VerifyError> {
+    if old_ibc_packet.status != PacketStatus::Ack {
+        return Err(VerifyError::WrongPacketStatus);
     }
 
     Ok(())

--- a/axon/src/message.rs
+++ b/axon/src/message.rs
@@ -37,8 +37,9 @@ impl_enum_rlp!(
         MsgRecvPacket,
         MsgWriteAckPacket,
         MsgAckPacket,
-
         MsgTimeoutPacket,
+
+        MsgConsumeAckPacket,
     },
     u8
 );
@@ -187,9 +188,15 @@ pub struct MsgWriteAckPacket {
     pub ack: Vec<u8>,
 }
 
+// If timeout block_number is set in Packet and reached, using MsgTimeoutPacket instead
 #[derive(RlpDecodable, RlpEncodable)]
 pub struct MsgTimeoutPacket {
     pub packet: Packet,
     pub next_sequence_recv: U256,
     pub proofs: Proofs,
 }
+
+// It's additional msg type which isn't contained in IBC, and just used
+// in Business side to be consumed to obtain its capacity
+#[derive(RlpDecodable, RlpEncodable)]
+pub struct MsgConsumeAckPacket {}


### PR DESCRIPTION
change log:
1. remove wrong comparison code in AckPacket, which is comparing old_packet.sequence to old_channel.sequence_sends
2. add `MsgConsumeAckPacket` message type to handle consume case in business side