### PR TITLE
chore: update axon_tools and re-export it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 [[package]]
 name = "axon-tools"
 version = "0.1.1"
-source = "git+https://github.com/axonweb3/axon.git?rev=06340ba4#06340ba42a752f9f31d38dab2dd40fa50ab2e239"
+source = "git+https://github.com/axonweb3/axon.git?rev=f889d38#f889d38949d6201c448ac72ebaec4d4fb0e5ba51"
 dependencies = [
  "bit-vec",
  "blst",

--- a/axon/Cargo.toml
+++ b/axon/Cargo.toml
@@ -4,15 +4,22 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rlp = {version = "0.5.2", default-features = false}
-rlp-derive = {version = "0.1.0", default-features = false}
-axon-tools = { git = "https://github.com/axonweb3/axon.git", rev = "06340ba4", features = ["proof"] }
+rlp = { version = "0.5.2", default-features = false }
+rlp-derive = { version = "0.1.0", default-features = false }
+axon-tools = { git = "https://github.com/axonweb3/axon.git", rev = "f889d38", features = [
+    "proof",
+] }
 axon-types = { git = "https://github.com/axonweb3/axon-contract", rev = "8106ddc0266" }
-ethereum-types = {version = "0.14.1", default-features = false, features= ["ethbloom", "rlp"]}
-tiny-keccak = {version = "2.0.2", features = ["keccak"]}
-bytes = { version = "1.4.0", default-features = false}
+ethereum-types = { version = "0.14.1", default-features = false, features = [
+    "ethbloom",
+    "rlp",
+] }
+tiny-keccak = { version = "2.0.2", features = ["keccak"] }
+bytes = { version = "1.4.0", default-features = false }
 sha2 = { version = "0.10.8", default-features = false }
-prost = { version = "0.12.1", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.12.1", default-features = false, features = [
+    "prost-derive",
+] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 molecule = { version = "0.7", default-features = false }
 

--- a/axon/src/lib.rs
+++ b/axon/src/lib.rs
@@ -46,6 +46,7 @@ pub mod handler;
 pub mod message;
 pub mod object;
 pub mod proto;
+pub use axon_tools;
 
 use axon_tools::keccak_256;
 use consts::CHANNEL_ID_PREFIX;


### PR DESCRIPTION
relayer and `ckb-ics` should use the same `axon-tools` crate version